### PR TITLE
feat(jinja2-webpack): Remove leading slash for empty public roots

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.1.4
+current_version = 0.2.0
 commit = True
 tag = True
 

--- a/README.rst
+++ b/README.rst
@@ -45,9 +45,9 @@ Overview
     :alt: PyPI Package latest release
     :target: https://pypi.python.org/pypi/jinja2-webpack
 
-.. |commits-since| image:: https://img.shields.io/github/commits-since/JDeuce/python-jinja2-webpack/v0.1.4.svg
+.. |commits-since| image:: https://img.shields.io/github/commits-since/JDeuce/python-jinja2-webpack/v0.2.0.svg
     :alt: Commits since latest release
-    :target: https://github.com/JDeuce/python-jinja2-webpack/compare/v0.1.4...master
+    :target: https://github.com/JDeuce/python-jinja2-webpack/compare/v0.2.0...master
 
 .. |wheel| image:: https://img.shields.io/pypi/wheel/jinja2-webpack.svg
     :alt: PyPI Wheel

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -26,7 +26,7 @@ project = u'jinja2-webpack'
 year = '2017'
 author = u'Josh Jaques'
 copyright = '{0}, {1}'.format(year, author)
-version = release = u'0.1.4'
+version = release = u'0.2.0'
 
 pygments_style = 'trac'
 templates_path = ['.']

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ def read(*names, **kwargs):
 
 setup(
     name='jinja2-webpack',
-    version='0.1.4',
+    version='0.2.0',
     license='BSD',
     description='Integration of webpack with jinja2',
     long_description='%s\n%s' % (

--- a/src/jinja2_webpack/__init__.py
+++ b/src/jinja2_webpack/__init__.py
@@ -65,9 +65,14 @@ class Environment(object):
             self._manifest = {}
 
     def _resolve_asset(self, asset):
+        if not self.settings.publicRoot:
+            url=asset
+        else:
+            url='%s/%s' % (self.settings.publicRoot, asset)
+
         return Asset(
             filename=asset,
-            url='%s/%s' % (self.settings.publicRoot, asset))
+            url=url)
 
     def _resolve_manifest(self, manifest):
         result = {}
@@ -125,4 +130,4 @@ class Environment(object):
         return renderer(asset)
 
 
-__version__ = '0.1.4'
+__version__ = '0.2.0'


### PR DESCRIPTION
I was running into an issue where I needed to _not_ have the leading slash for our webpack config. This fixes it and allows you to have CDN urls. Thanks again for the library it's been a big help@